### PR TITLE
Fix bug in BPE cache

### DIFF
--- a/Encoder.js
+++ b/Encoder.js
@@ -82,11 +82,11 @@ const byte_decoder = {}
 Object.keys(byte_encoder).map(x => { byte_decoder[byte_encoder[x]] = x })
 
 const bpe_ranks = dictZip(bpe_merges, range(0, bpe_merges.length))
-const cache = {}
+const cache = new Map;
 
 function bpe(token) {
-  if (token in cache) {
-    return cache[token]
+  if (cache.has(token)) {
+    return cache.get(token)
   }``
 
   let word = token.split('')
@@ -147,7 +147,7 @@ function bpe(token) {
   }
 
   word = word.join(' ')
-  cache[token] = word
+  cache.set(token, word)
 
   return word
 }

--- a/Encoder.test.js
+++ b/Encoder.test.js
@@ -35,3 +35,10 @@ test('emojis', () => {
   expect(encode(str)).toEqual([31373, 50169, 233, 995, 12520, 234, 235])
   expect(decode(encode(str))).toEqual(str)
 });
+
+test('properties of Object',()=>{
+	const str = "toString constructor hasOwnProperty valueOf";
+
+	expect(encode(str)).toEqual([1462, 10100, 23772, 468, 23858, 21746, 1988, 5189]);
+	expect(decode(encode(str))).toEqual(str);
+})


### PR DESCRIPTION
`bramses` reported this bug first in #8.

**Recreation**

```js
const {encode} = require('gpt-3-encoder')

const str = 'toString'
const encoded = encode(str)
// TypeError: bpe(...).split is not a function
```

**Explanation**

The `bpe()` method of the encoder uses a cache like so:

```js
const cache = {};

// ...

function bpe(token){
  if(token in cache) {
    return cache[token];
  }

  // otherwise, find the right word for the token...

  cache[token] = word
  return word
}
```

But `in` has some unexpected behavior:
```js
"toString" in {}; // true
({}).toString // f toString() { [native code] }
```

So calling `this.bpe("toString")` returns the function `Object.prototype.toString`. This causes an error.

**Fix**

I changed the implementation to use a JS `Map`, which is a better cache data structure that avoids this bug.

```js
const cache = new Map;
cache.has("toString"); // false
```